### PR TITLE
epicsdbbuilder.fanout - fix Python3 compatibility

### DIFF
--- a/epicsdbbuilder/fanout.py
+++ b/epicsdbbuilder/fanout.py
@@ -68,7 +68,7 @@ def create_fanout(name, *record_list, **args):
     firstargs = args
     nextargs = args.copy()
     nextargs['SCAN'] = 'Passive'
-    if nextargs.has_key('PINI'):  del nextargs['PINI']
+    if 'PINI' in nextargs:  del nextargs['PINI']
 
     def fieldname(i):   return 'LNK%d' % (i + 1)
     def identity(x):    return x
@@ -84,8 +84,8 @@ def create_dfanout(name, *record_list, **args):
     firstargs = args
     nextargs = args.copy()
     nextargs.update(dict(SCAN = 'Passive', OMSL = 'supervisory'))
-    if nextargs.has_key('DOL'):   del nextargs['DOL']
-    if nextargs.has_key('PINI'):  del nextargs['PINI']
+    if 'DOL' in nextargs:   del nextargs['DOL']
+    if 'PINI' in nextargs:  del nextargs['PINI']
 
     def fieldname(i):   return 'OUT%c' % (ord('A') + i)
     record_list = _fanout_helper(


### PR DESCRIPTION
Due to [fanout.py line 71](https://github.com/Araneidae/epicsdbbuilder/blob/8484609/epicsdbbuilder/fanout.py#L71), the  [example/test.py](https://github.com/Araneidae/epicsdbbuilder/blob/8484609/examples/test.py) currently doesn't work.

Python 3 changed checking for keys in dicts: [`dict.has_key()` is deprecated since a long time](https://docs.python.org/release/2.6/library/stdtypes.html?highlight=has_key#dict.has_key)
Also refer to [this hint from the "portingguide"](https://portingguide.readthedocs.io/en/latest/dicts.html#removed-dict-has-key).

Nice package BTW! Have you considered publishing this package in the Python Package Index? I'd be willing to give a hand if that would be helpful.