### PR TITLE
Add link options CA and CPP

### DIFF
--- a/epicsdbbuilder/recordbase.py
+++ b/epicsdbbuilder/recordbase.py
@@ -8,7 +8,7 @@ from . import recordnames
 from .recordset import recordset
 
 
-__all__ = ['PP', 'CP', 'MS', 'NP', 'ImportRecord']
+__all__ = ['PP', 'CA', 'CP', 'CPP', 'MS', 'NP', 'ImportRecord']
 
 
 
@@ -287,10 +287,21 @@ class _Link:
 def PP(record):
     return record('PP')
 
+# "Channel Access": a CA (input or output) link will be treated as a channel access link
+# regardless whether it is a DB link or not.
+def CA(record):
+    return record('CA')
+
 # "Channel Process": a CP input link will cause the linking record to process
 # any time the linked record is updated.
 def CP(record):
     return record('CP')
+
+# "Channel Process if Passive": a CP input link will be treated as a channel access link
+# and if the linking record is passive, the linking passive record will be processed
+# any time the linked record is updated.
+def CPP(record):
+    return record('CPP')
 
 # "Maximise Severity": any alarm state on the linked record is propogated to
 # the linking record.

--- a/examples/test.py
+++ b/examples/test.py
@@ -36,6 +36,15 @@ t = records.ai('TEST',
     INP = '@%s' % P, VAL = Q, SCAN = '1 second')
 records.bi('BOO', INP = s)
 
+# Test link options
+records.ai('OPTIONS:CA', INP = CA(t))
+records.ai('OPTIONS:CP', INP = CP(t))
+records.ai('OPTIONS:CPP', INP = CPP(t))
+
+# Test multiple link options
+records.ai('OPTIONS:PP:MS', INP = PP(MS(t)))
+
+
 if platform.system() == 'Windows':
     WriteRecords(os.path.join(os.path.dirname(__file__), 'test_output.db'))
 else:


### PR DESCRIPTION
**Problem**
EPICS supports link options CA, CP, and CPP which control behavior of a link which is treated as a channel access link. However, epicsdbbuilder supports CP only.

**Solution**
Add CA and CPP options.

**Test**
Extend with CA, CP, and CPP and run examples/test.py